### PR TITLE
Clarify unscored prediction tasks

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -45,6 +45,14 @@ The official metric is **Task Accuracy**:
 Task Accuracy = correct tasks / evaluated tasks
 ```
 
+The evaluated task set is defined exactly by the `task_*.json` files under
+`--config-root`; neither the input directory nor additional prediction
+directories change the denominator. Thus, the public 60-reference config set
+produces a denominator of 60, while the private official 410-reference config
+set produces a denominator of 410. Predictions for task IDs outside the active
+config set are not scored and are listed as `unscored_prediction_tasks` in the
+summary.
+
 Each task receives a binary score. A task is correct only when one
 one-to-one prediction-to-gold column mapping makes the complete predicted
 table equal to the gold table under the task configuration.

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -672,19 +672,19 @@ def evaluate_task(
     )
 
 
-def discover_unexpected_prediction_tasks(
+def discover_unscored_prediction_tasks(
     prediction_root: Path,
-    expected_task_ids: set[str],
+    evaluated_task_ids: set[str],
 ) -> list[str]:
-    unexpected: list[str] = []
+    unscored: list[str] = []
     for path in prediction_root.iterdir():
         if (
             path.is_dir()
             and TASK_ID_PATTERN.fullmatch(path.name)
-            and path.name not in expected_task_ids
+            and path.name not in evaluated_task_ids
         ):
-            unexpected.append(path.name)
-    return sorted(unexpected, key=natural_task_key)
+            unscored.append(path.name)
+    return sorted(unscored, key=natural_task_key)
 
 
 def evaluate_suite(
@@ -701,7 +701,7 @@ def evaluate_suite(
         raise EvaluationFatalError(f"Missing gold root directory: {gold_root}")
 
     configs = load_configs(config_root)
-    all_expected_task_ids = {
+    evaluated_task_ids = {
         path.stem
         for path in config_root.glob("task_*.json")
         if TASK_ID_PATTERN.fullmatch(path.stem)
@@ -729,9 +729,9 @@ def evaluate_suite(
         "passed_task_count": passed_task_count,
         "failed_task_count": task_count - passed_task_count,
         "task_accuracy": passed_task_count / task_count if task_count else 0.0,
-        "unexpected_prediction_tasks": discover_unexpected_prediction_tasks(
+        "unscored_prediction_tasks": discover_unscored_prediction_tasks(
             prediction_root,
-            all_expected_task_ids,
+            evaluated_task_ids,
         ),
         "tasks": [result.to_dict() for result in results],
     }

--- a/evaluation/tests/test_cli.py
+++ b/evaluation/tests/test_cli.py
@@ -40,8 +40,14 @@ class EvaluatorCliTests(unittest.TestCase):
             prediction.mkdir(parents=True)
             gold.mkdir(parents=True)
             configs.mkdir()
+            unscored_prediction = root / "predictions" / "task_2"
+            unscored_prediction.mkdir()
             (prediction / "prediction.csv").write_text(
                 "answer\nA\n",
+                encoding="utf-8",
+            )
+            (unscored_prediction / "prediction.csv").write_text(
+                "answer\nB\n",
                 encoding="utf-8",
             )
             (gold / "gold.csv").write_text(
@@ -88,8 +94,11 @@ class EvaluatorCliTests(unittest.TestCase):
             self.assertEqual(completed.returncode, 0, completed.stderr)
             summary = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(summary["metric"], "task_accuracy")
+            self.assertEqual(summary["task_count"], 1)
             self.assertEqual(summary["passed_task_count"], 1)
             self.assertEqual(summary["task_accuracy"], 1.0)
+            self.assertEqual(summary["unscored_prediction_tasks"], ["task_2"])
+            self.assertNotIn("unexpected_prediction_tasks", summary)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Rename `unexpected_prediction_tasks` to `unscored_prediction_tasks` in evaluator summaries.
- Document that the active config set defines the evaluation universe and Task Accuracy denominator.
- Add a CLI regression test showing that predictions outside the config set do not affect `task_count` or accuracy.

## Why

The public benchmark contains all 410 inputs but only 60 public gold/config pairs. A user may therefore generate 410 predictions while evaluating locally against 60 references. Those additional predictions are valid benchmark outputs; they are simply unscored by the public config set and should not be described as unexpected.

The scoring behavior is unchanged: the public config set yields a denominator of 60, while the private official config set yields a denominator of 410.

## Validation

- `python3 -m unittest discover -s evaluation/tests -v` (18 tests passed)
- `python3 -m compileall -q evaluation`
- `git diff --check`